### PR TITLE
Changing the publishing delays is not allowed.

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,0 @@
-{
-  "publish-delay-hours": 1
-}

--- a/hu.irl.cameractrls.yml
+++ b/hu.irl.cameractrls.yml
@@ -6,7 +6,6 @@ finish-args:
   - --device=all
   - --share=ipc
   - --socket=x11
-  - --socket=wayland
 command: cameractrlsgtk.py
 cleanup:
   - /include


### PR DESCRIPTION
This is now strictly enforced

See failure on #1

Also remove wayland socket according to commit 197fcfb25644369a55a4fc280d1f57abe3c94817